### PR TITLE
Validation Updates after Francis Testing

### DIFF
--- a/TechKnowPro/PasswordReset3.aspx.cs
+++ b/TechKnowPro/PasswordReset3.aspx.cs
@@ -27,7 +27,7 @@ namespace TechKnowPro
             PasswordValidator pv = new PasswordValidator(txtPassword1.Text);
             if (!pv.isValid())
             {
-                lblErr.Text = "Password is missing at least 1 uppercase<br/> and 1 special character";
+                lblErr.Text = "Password must contain at least 1 uppercase and 1 special character";
                 return;
             }
 

--- a/TechKnowPro/ProfileForm.aspx
+++ b/TechKnowPro/ProfileForm.aspx
@@ -116,14 +116,11 @@
                 </tr>
                 <tr>
                     <td class="auto-style3">
-                        <asp:Label ID="Label5" runat="server" Text="*Password:"></asp:Label>
+                        <asp:Label ID="Label5" runat="server" Text="Password:"></asp:Label>
                     </td>
                     <td>
                         <asp:TextBox ID="txtPass" runat="server" Width="260px" CssClass="textbox2" TextMode="Password"></asp:TextBox>
                         <asp:RegularExpressionValidator ID="RegularExpressionValidator1" runat="server" ControlToValidate="txtPass" ErrorMessage="Password length must be from 6 - 12 characters!" ForeColor="Red" ValidationExpression="^.{6,12}$">*</asp:RegularExpressionValidator>
-
-                        <asp:RequiredFieldValidator ID="RequiredFieldValidator12" runat="server" ControlToValidate="txtPass" Display="Dynamic" ErrorMessage="Password is required" ForeColor="Red">*</asp:RequiredFieldValidator>
-
                     </td>
                 </tr>
                 <tr>
@@ -188,6 +185,7 @@
                         <asp:TextBox ID="txtEmail" runat="server" Width="260px" TextMode="Email" CssClass="textbox2"></asp:TextBox>
                         <asp:RequiredFieldValidator ID="RequiredFieldValidator10" runat="server" ControlToValidate="txtEmail" Display="Dynamic" ErrorMessage="Email is required" ForeColor="Red">*</asp:RequiredFieldValidator>
                         <asp:CompareValidator ID="CompareValidator1" runat="server" ErrorMessage="Email and Username must be the same" ControlToCompare="txtEmail" ControlToValidate="txtUser" ForeColor="Red">*</asp:CompareValidator>
+                        <asp:RegularExpressionValidator ID="RegularExpressionValidator4" runat="server" ErrorMessage="Must be a valid email!" ForeColor="Red" ValidationExpression="\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*" ControlToValidate="txtEmail">*</asp:RegularExpressionValidator>
                     </td>
                 </tr>
                 <tr>

--- a/TechKnowPro/ProfileForm.aspx.cs
+++ b/TechKnowPro/ProfileForm.aspx.cs
@@ -82,17 +82,18 @@ namespace TechKnowPro
         protected void btnUpdate_Click(object sender, EventArgs e)
         {
             lblSucc.Text = "";
-            //validate password
-            PasswordValidator pv = new PasswordValidator(txtPass.Text);
-            if (!pv.isValid())
-            {
-                lblSucc.Text = "Password is missing at least 1 uppercase and 1 special character";
-                return;
-            }
 
             //if password is updated
-            if (txtPass.Text != null)
+            if (txtPass.Text != "")
             {
+                //validate password
+                PasswordValidator pv = new PasswordValidator(txtPass.Text);
+                if (!pv.isValid())
+                {
+                    lblSucc.Text = "Password must contain at least 1 uppercase and 1 special character";
+                    return;
+                }
+
                 //password hashing
                 Hasher hashP = new Hasher(txtPass.Text);
                 Session["password"] = hashP.getHashedPassword();

--- a/TechKnowPro/ProfileForm.aspx.designer.cs
+++ b/TechKnowPro/ProfileForm.aspx.designer.cs
@@ -121,15 +121,6 @@ namespace TechKnowPro {
         protected global::System.Web.UI.WebControls.RegularExpressionValidator RegularExpressionValidator1;
         
         /// <summary>
-        /// RequiredFieldValidator12 control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.RequiredFieldValidator RequiredFieldValidator12;
-        
-        /// <summary>
         /// lblSucc control.
         /// </summary>
         /// <remarks>
@@ -326,6 +317,15 @@ namespace TechKnowPro {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CompareValidator CompareValidator1;
+        
+        /// <summary>
+        /// RegularExpressionValidator4 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.RegularExpressionValidator RegularExpressionValidator4;
         
         /// <summary>
         /// Label14 control.

--- a/TechKnowPro/Registration.aspx.cs
+++ b/TechKnowPro/Registration.aspx.cs
@@ -34,7 +34,7 @@ namespace TechKnowPro
             PasswordValidator pv = new PasswordValidator(txtPass1.Text);
             if (!pv.isValid())
             {
-                lblSuccOrErr.Text = "Password is missing at least 1 uppercase<br/> and 1 special character";
+                lblSuccOrErr.Text = "Password must contain least 1 uppercase<br/> and 1 special character";
                 return;
             }
 


### PR DESCRIPTION
1. Replaced password error message to: "Password must contain at least 1 uppercase and 1 special character" rather than "Password is missing at least 1 uppercase and 1 special char" because user might add an uppercase without special character and message will still say that it's missing both uppercase and special character.
2.  Profile form: Password should not be required in update profile. If no password, password will not update.
3.  Profile form: There should be email validation as well. I was able to update my email to kirito@isp without the .com. So when I logged out, there was no way I could log in anymore.